### PR TITLE
Add stdlib and stdio include preprocessor

### DIFF
--- a/packlib/kernlib/kernbit/t002/unalign.c
+++ b/packlib/kernlib/kernbit/t002/unalign.c
@@ -20,6 +20,6 @@
 */
 void allow_unaligned_data_access_()
 {
-     allow_unaligned_data_access();
+     allow_unaligned_data_access_();
 }
 #endif

--- a/packlib/kernlib/kerngen/ccgen/abend.c
+++ b/packlib/kernlib/kerngen/ccgen/abend.c
@@ -14,6 +14,7 @@
  */
 #include "kerngen/pilot.h"
 #include "kerngen/fortranc.h"
+#include <stdlib.h>
 
 /*>    ROUTINE ABEND
   CERN PROGLIB# Z035    ABEND           .VERSION KERNFOR  4.31  911111

--- a/packlib/kernlib/kerngen/ccgen/accesi.c
+++ b/packlib/kernlib/kerngen/ccgen/accesi.c
@@ -16,6 +16,7 @@
  *
  */
 #include "kerngen/pilot.h"
+#include <stdlib.h>
 #ifdef CERNLIB_WINNT
 #  include <io.h>
 #endif
@@ -73,7 +74,7 @@ int type_of_call ACCESI(fname,
       if (ptf == NULL)                goto exit;
 
       umode = *mode & 7;
-      istat = access(ptf, umode);
+      istat = accesi_(ptf, umode);
       free(ptf);
 
 exit:

--- a/packlib/kernlib/kerngen/ccgen/chdiri.c
+++ b/packlib/kernlib/kerngen/ccgen/chdiri.c
@@ -29,6 +29,7 @@
          ISTAT  returns zero if successful
 */
 #include <stdio.h>
+#include <stdlib.h>
 #ifdef WIN32
 #include <direct.h>
 # ifndef chdir

--- a/packlib/kernlib/kerngen/ccgen/ctimef.c
+++ b/packlib/kernlib/kerngen/ccgen/ctimef.c
@@ -14,6 +14,7 @@
  */
 #include "kerngen/pilot.h"
 #include "kerngen/fortranc.h"
+#include <string.h>
 
 /*>    ROUTINE CTIMEF (CLOCK, STIME)
   CERN PROGLIB# Z265    CTIMEF          .VERSION KERNFOR  4.36  930602

--- a/packlib/kernlib/kerngen/ccgen/exitf.c
+++ b/packlib/kernlib/kerngen/ccgen/exitf.c
@@ -14,6 +14,7 @@
  */
 #include "kerngen/pilot.h"
 #include "kerngen/fortranc.h"
+#include <stdlib.h>
 
 /*>    ROUTINE EXITF
   CERN PROGLIB# Z035    EXITF           .VERSION KERNFOR  4.39  940228

--- a/packlib/kernlib/kerngen/ccgen/geteni.c
+++ b/packlib/kernlib/kerngen/ccgen/geteni.c
@@ -30,6 +30,7 @@
                 ISLATE(1) returns its length
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include "kerngen/fortchar.h"
 #if defined(CERNLIB_QX_SC)
 void type_of_call geteni_(fname, ftext, lgtext, lgname)

--- a/packlib/kernlib/kerngen/ccgen/getwdi.c
+++ b/packlib/kernlib/kerngen/ccgen/getwdi.c
@@ -29,6 +29,7 @@
       ISLATE(1) returns its lenth NTEXT
 */
 #include <stdio.h>
+#include <stdlib.h>
 #ifdef WIN32
 #include <direct.h>
 # ifndef getcwd
@@ -58,7 +59,7 @@ void type_of_call getwdi(fname, lgname)
 #endif
       int  *lgname;
 {
-      char *malloc();
+      // char *malloc();
       char *ptalc, *pttext;
       int  fchput();
       int  nalc;

--- a/packlib/kernlib/kerngen/ccgen/intrac.c
+++ b/packlib/kernlib/kerngen/ccgen/intrac.c
@@ -13,6 +13,7 @@
  * 
  */
 #include "kerngen/pilot.h"
+#include <unistd.h>
 #if defined(CERNLIB_WINNT)
 #include "wntgs/intrac.c"
 #elif defined(CERNLIB_QMDOS)

--- a/packlib/kernlib/kerngen/ccgen/jmplong.c
+++ b/packlib/kernlib/kerngen/ccgen/jmplong.c
@@ -16,6 +16,7 @@
  *
  */
 #include "kerngen/pilot.h"
+#include <setjmp.h>
 
 /*>    ROUTINE JMPLONG
   CERN PROGLIB#         JMPLONG         .VERSION KERNFOR  4.36  930602

--- a/packlib/kernlib/kerngen/ccgen/lstati.c
+++ b/packlib/kernlib/kerngen/ccgen/lstati.c
@@ -26,6 +26,7 @@ C ORIG. 24/03/91, RDM + JZ
   Fortran interface routine to lstat
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "kerngen/fortchar.h"

--- a/packlib/kernlib/kerngen/ccgen/perroi.c
+++ b/packlib/kernlib/kerngen/ccgen/perroi.c
@@ -28,6 +28,7 @@
           TEXT  the text to be printed before the error message
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include "kerngen/fortchar.h"
 #if defined(CERNLIB_QX_SC)
 void type_of_call perroi_(ftext, lgtext)

--- a/packlib/kernlib/kerngen/ccgen/readlni.c
+++ b/packlib/kernlib/kerngen/ccgen/readlni.c
@@ -27,6 +27,7 @@
           NCH   returns the length of the value
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include "kerngen/fortchar.h"
 #if defined(CERNLIB_QX_SC)
 int type_of_call readlni_(fname, ftext, lgtext, lgname)

--- a/packlib/kernlib/kerngen/ccgen/renami.c
+++ b/packlib/kernlib/kerngen/ccgen/renami.c
@@ -27,6 +27,7 @@
          ISTAT  zero if successful
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include "kerngen/fortchar.h"
 #if defined(CERNLIB_QX_SC)
 int type_of_call renami_(frpath, topath, lgfr, lgto)

--- a/packlib/kernlib/kerngen/ccgen/stati.c
+++ b/packlib/kernlib/kerngen/ccgen/stati.c
@@ -26,6 +26,7 @@ C ORIG. 14/03/91, RDM
   Fortran interface routine to stat
 */
 #include <stdio.h>
+#include <stdlib.h>
 #if defined(CERNLIB_QMVAX)||defined(CERNLIB_QMOS9)
 #include <types.h>
 #include <stat.h>

--- a/packlib/kernlib/kerngen/ccgen/systei.c
+++ b/packlib/kernlib/kerngen/ccgen/systei.c
@@ -29,6 +29,7 @@
          ISTAT  returns zero if successful
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include "kerngen/fortchar.h"
 
 #if defined(CERNLIB_QX_SC)

--- a/packlib/kernlib/kerngen/ccgen/tmproi.c
+++ b/packlib/kernlib/kerngen/ccgen/tmproi.c
@@ -29,6 +29,7 @@
 #include <io.h>
 #endif
 #include <stdio.h>
+#include <unistd.h>
 #include "kerngen/fortchar.h"
 #if defined(CERNLIB_QX_SC)
 void tmproi_(ftext, lgtext)

--- a/packlib/kernlib/kerngen/ccgen/unlini.c
+++ b/packlib/kernlib/kerngen/ccgen/unlini.c
@@ -29,6 +29,7 @@
          ISTAT  returns zero if successful
 */
 #include <stdio.h>
+#include <stdlib.h>
 #include "kerngen/fortchar.h"
 #if defined(CERNLIB_QX_SC)
 int type_of_call unlini_(fname,lgname)

--- a/packlib/kernlib/kerngen/ccgencf/cfget.c
+++ b/packlib/kernlib/kerngen/ccgencf/cfget.c
@@ -43,8 +43,11 @@
 #ifndef WIN32
 #  include <errno.h>
 #else
-#  include <stdlib.h>
+#include <stdlib.h>
+#include <errno.h>
 #endif
+#include <errno.h>
+#include <stdio.h>
 #include "kerngen/cf_xaft.h"
 #include "kerngen/wordsizc.h"
 #if defined(CERNLIB_QX_SC)

--- a/packlib/kernlib/kerngen/ccgencf/cfopei.c
+++ b/packlib/kernlib/kerngen/ccgencf/cfopei.c
@@ -44,6 +44,8 @@
       *ISTAT   status, =zero if success
 */
 #include "kerngen/cf_open.h"
+#include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 #include "kerngen/cf_xaft.h"
 #include "kerngen/fortchar.h"

--- a/packlib/kernlib/kerngen/ccgencf/cfput.c
+++ b/packlib/kernlib/kerngen/ccgencf/cfput.c
@@ -33,6 +33,8 @@
       *ISTAT   status, =zero if success
 */
 #include "kerngen/cf_reaw.h"
+#include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 #include "kerngen/cf_xaft.h"
 #include "kerngen/wordsizc.h"

--- a/packlib/kernlib/kerngen/ccgencf/cfrew.c
+++ b/packlib/kernlib/kerngen/ccgencf/cfrew.c
@@ -25,6 +25,9 @@
 */
 #include "kerngen/cf_seek.h"
 #include "kerngen/cf_xaft.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 
 #if defined(CERNLIB_QX_SC)
 void type_of_call cfrew_(lundes, medium)

--- a/packlib/kernlib/kerngen/ccgencf/cfseek.c
+++ b/packlib/kernlib/kerngen/ccgencf/cfseek.c
@@ -28,6 +28,9 @@
 #include "kerngen/cf_xaft.h"
 #include "kerngen/wordsizc.h"
 #include "kerngen/fortranc.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 
 #if defined(CERNLIB_QX_SC)
 void type_of_call cfseek_(lundes, medium, nwrec, jcrec, stat)

--- a/packlib/kernlib/kerngen/ccgencf/cfsize.c
+++ b/packlib/kernlib/kerngen/ccgencf/cfsize.c
@@ -28,6 +28,9 @@
 #include "kerngen/cf_xaft.h"
 #include "kerngen/wordsizc.h"
 #include "kerngen/fortranc.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 
 #if defined(CERNLIB_QX_SC)
 void type_of_call cfsize_(lundes, medium, nwrec, jrecl, stat)

--- a/packlib/kernlib/kerngen/ccgencf/cftell.c
+++ b/packlib/kernlib/kerngen/ccgencf/cftell.c
@@ -28,6 +28,9 @@
 #include "kerngen/cf_xaft.h"
 #include "kerngen/wordsizc.h"
 #include "kerngen/fortranc.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 
 #if defined(CERNLIB_QX_SC)
 void type_of_call cftell_(lundes, medium, nwrec, jcrec, stat)

--- a/packlib/kernlib/kerngen/ccgenci/ciget.c
+++ b/packlib/kernlib/kerngen/ccgenci/ciget.c
@@ -34,7 +34,9 @@
 */
 #include "kerngen/cf_reaw.h"
 #ifndef WIN32
-#  include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #else
 #  include <stdlib.h>
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/cigetw.c
+++ b/packlib/kernlib/kerngen/ccgenci/cigetw.c
@@ -34,7 +34,9 @@
 */
 #include "kerngen/cf_reaw.h"
 #ifndef WIN32
-#  include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #else
 #  include <stdlib.h>
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/ciopei.c
+++ b/packlib/kernlib/kerngen/ccgenci/ciopei.c
@@ -37,7 +37,9 @@
 */
 #include "kerngen/cf_open.h"
 #ifndef WIN32
-#  include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #else
 #  include <stdlib.h>
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/ciput.c
+++ b/packlib/kernlib/kerngen/ccgenci/ciput.c
@@ -33,7 +33,9 @@
 */
 #include "kerngen/cf_reaw.h"
 #ifndef WIN32
-#  include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #else
 #  include <stdlib.h>
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/ciputw.c
+++ b/packlib/kernlib/kerngen/ccgenci/ciputw.c
@@ -33,7 +33,9 @@
 */
 #include "kerngen/cf_reaw.h"
 #ifndef WIN32
-#  include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #else
 #  include <stdlib.h>
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/cirew.c
+++ b/packlib/kernlib/kerngen/ccgenci/cirew.c
@@ -28,6 +28,10 @@
 #include "kerngen/cf_seek.h"
 #include "kerngen/cf_xaft.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
 #if defined(CERNLIB_QX_SC)
 void type_of_call cirew_(lundes)
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/ciseek.c
+++ b/packlib/kernlib/kerngen/ccgenci/ciseek.c
@@ -26,6 +26,9 @@
 */
 #include "kerngen/cf_seek.h"
 #include "kerngen/cf_xaft.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #if defined(CERNLIB_QX_SC)
 void type_of_call ciseek_(lundes, jcbyt, stat)
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/cisize.c
+++ b/packlib/kernlib/kerngen/ccgenci/cisize.c
@@ -26,6 +26,9 @@
 */
 #include "kerngen/cf_seek.h"
 #include "kerngen/cf_xaft.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #if defined(CERNLIB_QX_SC)
 void type_of_call cisize_(lundes, jbytl, stat)
 #endif

--- a/packlib/kernlib/kerngen/ccgenci/citell.c
+++ b/packlib/kernlib/kerngen/ccgenci/citell.c
@@ -26,6 +26,9 @@
 */
 #include "kerngen/cf_seek.h"
 #include "kerngen/cf_xaft.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 #if defined(CERNLIB_QX_SC)
 void type_of_call citell_(lundes, jcbyt, stat)
 #endif


### PR DESCRIPTION
Dear @sly2j 

Thanks a lot for porting cernlib to modern compilers!
I have tested the installation on my machine (Mac ARM-M1, gcc 11+) and it seems to fail building.
I was able to fix this easily by manually adding all the stdlib headers.

I also add an issue with the allow_unaligned_data_access function and accesi_ (compiler complains these have no forward declaration); easy fix, but it is unclear if I should do more?

Can you have a look and tell me if this works?

Thanks a lot!
