### PR TITLE
Reordered linking - plase don't merge blindly

### DIFF
--- a/cmake/nanocernlib-config.cmake.in
+++ b/cmake/nanocernlib-config.cmake.in
@@ -31,10 +31,11 @@ endif()
 # all libraries are mentioned twice to satisfy gcc in the case of
 # cross-dependencies
 set(NANOCERNLIB_LIBRARIES 
-  nanocernlib_packlib 
-  nanocernlib_mathlib
+  nanocernlib_geant321
   nanocernlib_mclibs
-  nanocernlib_geant321)
+  nanocernlib_mathlib
+  nanocernlib_packlib 
+)
 set(NANOCERNLIB_LIBRARIES ${NANOCERNLIB_LIBRARIES} ${NANOCERNLIB_LIBRARIES})
 
 ## packlib 


### PR DESCRIPTION
I found while hacking up PEPSI by hand
https://gitlab.com/eic/mceg/pepsi/-/commit/84ca2fd52e8e0ff3a84da73c768a2eb12e1efdde
that repetition isn't enough.

It may actually not even be needed. If that's the case, l. 39,
```
set(NANOCERNLIB_LIBRARIES ${NANOCERNLIB_LIBRARIES} ${NANOCERNLIB_LIBRARIES})
```
can be deleted too. 

But I don't have enough test cases to be comfortable just pulling this change in. Opinions?
